### PR TITLE
サインインフォームを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 gem 'bcrypt', '~> 3.1.7'
 gem 'coffee-rails', '~> 4.2'
 gem 'jbuilder', '~> 2.5'
+gem 'jwt'
 gem 'puma', '~> 3.7'
 gem 'rails', '~> 5.1.4'
 gem 'sass-rails', '~> 5.0'
@@ -25,7 +26,7 @@ gem 'webpacker', github: 'rails/webpacker'
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'capybara', '~> 2.13'
-  gem "letter_opener"
+  gem 'letter_opener'
   gem 'selenium-webdriver'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jwt (2.1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.4.1)
@@ -196,6 +197,7 @@ DEPENDENCIES
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
+  jwt
   letter_opener
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.7)

--- a/app/controllers/signin_controller.rb
+++ b/app/controllers/signin_controller.rb
@@ -2,4 +2,28 @@
 class SigninController < ApplicationController
   def new
   end
+  def issue_jwt
+    workspace = Workspace.find_by(domain: signin_params[:domain])
+    user = User.where(workspace_id: workspace.id).find_by(email: signin_params[:email])
+    if user&.authenticate(signin_params[:password])
+      payload = { email: signin_params[:email],
+                  workspace_id: workspace.id,
+                  workspace_name: workspace.name,
+                  domain: workspace.domain }
+      token = JWT.encode(payload, Rails.application.secrets.secret_key_base, 'HS256')
+      if user.update_attribute(:token, token)
+        render json: { success: true, token: token }
+      else
+        render json: { success: false }
+      end
+    else
+      render json: { success: false }
+    end
+  end
+
+  private
+
+  def signin_params
+    params.require(:signin).permit(:domain, :email, :password)
+  end
 end

--- a/app/controllers/signin_controller.rb
+++ b/app/controllers/signin_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+class SigninController < ApplicationController
+  def new
+  end
+end

--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -7,7 +7,7 @@ class WorkspacesController < ApplicationController
     if workspace.where(domain: workspace_params[:domain]).count.zero?
       render json: { success: true }
     else
-      render json: { success: false }
+      render json: { success: false, name: workspace.find_by(domain: workspace_params[:domain]).name }
     end
   end
   def create_with_user

--- a/app/javascript/packs/signin.jsx
+++ b/app/javascript/packs/signin.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import WorkspaceDomain from './signin/workspace_domain.jsx'
+import EmailPassword from './signin/email_password.jsx'
+
+class Parent extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      domain: "",
+      workspace_name: "",
+      email: "",
+      password: "",
+      style_workspace: "visible",
+      style_email_password: "hidden",
+      csrf_token: document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+    }
+  }
+  update_domain(obj) {
+    this.setState(obj)
+    this.setState({style_workspace: "hidden", style_email_password: "visible"})
+  }
+  update_email_password(obj) {
+    this.setState(obj, () => {
+      console.log(this.state)
+    })
+  }
+  render() {
+    return (
+      <div className="form_wrapper">
+        <WorkspaceDomain style={this.state.style_workspace} update_domain={this.update_domain.bind(this)}  csrf_token={this.state.csrf_token}/>
+        <EmailPassword style={this.state.style_email_password} parentstate={this.state} update_email_password={this.update_email_password.bind(this)} csrf_token={this.state.csrf_token}/>
+      </div>
+    )
+  }
+}
+
+ReactDOM.render(
+  <Parent/>, document.getElementById("content"))

--- a/app/javascript/packs/signin.jsx
+++ b/app/javascript/packs/signin.jsx
@@ -23,13 +23,22 @@ class Parent extends React.Component {
   }
   update_email_password(obj) {
     this.setState(obj, () => {
-      console.log(this.state)
+      this.set_localstorage()
     })
   }
+  set_localstorage() {
+    // jwtとワークスペース名はjsonでlocalstorageに保存
+    let data = {
+      token: this.state.token,
+      workspace_name: this.state.workspace_name
+    }
+    localStorage.setItem(this.state.domain, JSON.stringify(data))
+  }
+
   render() {
     return (
       <div className="form_wrapper">
-        <WorkspaceDomain style={this.state.style_workspace} update_domain={this.update_domain.bind(this)}  csrf_token={this.state.csrf_token}/>
+        <WorkspaceDomain style={this.state.style_workspace} update_domain={this.update_domain.bind(this)} csrf_token={this.state.csrf_token}/>
         <EmailPassword style={this.state.style_email_password} parentstate={this.state} update_email_password={this.update_email_password.bind(this)} csrf_token={this.state.csrf_token}/>
       </div>
     )

--- a/app/javascript/packs/signin/email_password.jsx
+++ b/app/javascript/packs/signin/email_password.jsx
@@ -24,9 +24,11 @@ export default class EmailPassword extends React.Component {
     })
     axios.defaults.headers['X-CSRF-TOKEN'] = this.props.csrf_token
     axios.post('/signin', {
-      domain: this.props.parentstate.domain,
-      email: input_email,
-      password: input_password
+      signin: {
+        domain: this.props.parentstate.domain,
+        email: input_email,
+        password: input_password
+      }
     }).then((results) => {
       if (results.data.success) {
         // Parentのステートを更新
@@ -39,28 +41,29 @@ export default class EmailPassword extends React.Component {
           }
         })
 
-        }},).catch(() => {
-        alert('エラー')
-        this.setState({isdisabled: false})
-      });
-    }
-
-    render() {
-      return (
-        <form id="domain_form" style={{
-          visibility: this.props.style
-        }}>
-          <h1>{this.props.parentstate.workspace_name}({this.props.parentstate.domain})にサインイン</h1>
-          <p>メールアドレスとパスワードを入力してください</p>
-          <label>メールアドレス</label>
-          <input type="text" id="email_input" className="biginput"/>
-          <label>パスワード</label>
-          <input type="password" id="password_input" className="biginput"/>
-          <p className="existence_error" style={this.state.error_style}>メールアドレスかパスワードが間違っています。</p>
-          <button onClick={this.signin.bind(this)} id="submit_domain" disabled={this.state.isdisabled}>
-            続行する
-          </button>
-        </form >
-      );
-    }
+      }
+    },).catch(() => {
+      alert('エラー')
+      this.setState({isdisabled: false})
+    });
   }
+
+  render() {
+    return (
+      <form id="domain_form" style={{
+        visibility: this.props.style
+      }}>
+        <h1>{this.props.parentstate.workspace_name}({this.props.parentstate.domain})にサインイン</h1>
+        <p>メールアドレスとパスワードを入力してください</p>
+        <label>メールアドレス</label>
+        <input type="text" id="email_input" className="biginput"/>
+        <label>パスワード</label>
+        <input type="password" id="password_input" className="biginput"/>
+        <p className="existence_error" style={this.state.error_style}>メールアドレスかパスワードが間違っています。</p>
+        <button onClick={this.signin.bind(this)} id="submit_domain" disabled={this.state.isdisabled}>
+          続行する
+        </button>
+      </form >
+    );
+  }
+}

--- a/app/javascript/packs/signin/email_password.jsx
+++ b/app/javascript/packs/signin/email_password.jsx
@@ -14,8 +14,8 @@ export default class EmailPassword extends React.Component {
   }
 
   signin() {
-    let input_email = document.getElementById('email_input').value
-    let input_password = document.getElementById('password_input').value
+    let input_email = this.refs.email.value
+    let input_password = this.refs.password.value
     this.setState({
       isdisabled: true,
       error_style: {
@@ -56,9 +56,9 @@ export default class EmailPassword extends React.Component {
         <h1>{this.props.parentstate.workspace_name}({this.props.parentstate.domain})にサインイン</h1>
         <p>メールアドレスとパスワードを入力してください</p>
         <label>メールアドレス</label>
-        <input type="text" id="email_input" className="biginput"/>
+        <input type="text" id="email_input" className="biginput" ref="email"/>
         <label>パスワード</label>
-        <input type="password" id="password_input" className="biginput"/>
+        <input type="password" id="password_input" className="biginput" ref="password"/>
         <p className="existence_error" style={this.state.error_style}>メールアドレスかパスワードが間違っています。</p>
         <button onClick={this.signin.bind(this)} id="submit_domain" disabled={this.state.isdisabled}>
           続行する

--- a/app/javascript/packs/signin/email_password.jsx
+++ b/app/javascript/packs/signin/email_password.jsx
@@ -32,7 +32,7 @@ export default class EmailPassword extends React.Component {
     }).then((results) => {
       if (results.data.success) {
         // Parentのステートを更新
-        this.props.update_email_password({email: input_email, password: input_password})
+        this.props.update_email_password({email: input_email, password: input_password, token: results.data.token})
       } else {
         this.setState({isdisabled: false})
         this.setState({

--- a/app/javascript/packs/signin/email_password.jsx
+++ b/app/javascript/packs/signin/email_password.jsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import axios from 'axios'
+
+export default class EmailPassword extends React.Component {
+  constructor(props) {
+    super(props)
+    // stateの初期値を設定
+    this.state = {
+      isdisabled: false,
+      error_style: {
+        display: "none"
+      }
+    }
+  }
+
+  signin() {
+    let input_email = document.getElementById('email_input').value
+    let input_password = document.getElementById('password_input').value
+    this.setState({
+      isdisabled: true,
+      error_style: {
+        display: "none"
+      }
+    })
+    axios.defaults.headers['X-CSRF-TOKEN'] = this.props.csrf_token
+    axios.post('/signin', {
+      domain: this.props.parentstate.domain,
+      email: input_email,
+      password: input_password
+    }).then((results) => {
+      if (results.data.success) {
+        // Parentのステートを更新
+        this.props.update_email_password({email: input_email, password: input_password})
+      } else {
+        this.setState({isdisabled: false})
+        this.setState({
+          error_style: {
+            display: "block"
+          }
+        })
+
+        }},).catch(() => {
+        alert('エラー')
+        this.setState({isdisabled: false})
+      });
+    }
+
+    render() {
+      return (
+        <form id="domain_form" style={{
+          visibility: this.props.style
+        }}>
+          <h1>{this.props.parentstate.workspace_name}({this.props.parentstate.domain})にサインイン</h1>
+          <p>メールアドレスとパスワードを入力してください</p>
+          <label>メールアドレス</label>
+          <input type="text" id="email_input" className="biginput"/>
+          <label>パスワード</label>
+          <input type="password" id="password_input" className="biginput"/>
+          <p className="existence_error" style={this.state.error_style}>メールアドレスかパスワードが間違っています。</p>
+          <button onClick={this.signin.bind(this)} id="submit_domain" disabled={this.state.isdisabled}>
+            続行する
+          </button>
+        </form >
+      );
+    }
+  }

--- a/app/javascript/packs/signin/workspace_domain.jsx
+++ b/app/javascript/packs/signin/workspace_domain.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import axios from 'axios'
+
+export default class WorkspaceDomain extends React.Component {
+  constructor(props) {
+    super(props)
+    // stateの初期値を設定
+    this.state = {
+      isdisabled: false,
+      error_style: {
+        display: "none"
+      }
+    }
+  }
+  confirm_domain() {
+    let input_domain = document.getElementById('domain_input').value
+    this.setState({
+      isdisabled: true,
+      error_style: {
+        display: "none"
+      }
+    })
+    axios.defaults.headers['X-CSRF-TOKEN'] = this.props.csrf_token
+    axios.post('/workspaces/domain/check', {domain: input_domain}).then((results) => {
+      if (!results.data.success) {
+        // Parentのステートを更新
+        this.props.update_domain({domain: input_domain, workspace_name: results.data.name})
+      } else {
+        this.setState({
+          isdisabled: false,
+          error_style: {
+            display: "block"
+          }
+        })
+      }
+    },).catch(() => {
+      alert('エラー')
+      this.setState({isdisabled: false})
+    });
+  }
+
+  render() {
+    return (
+      <form id="domain_form" style={{
+        visibility: this.props.style
+      }}>
+        <h1>ワークスペースにサインインする</h1>
+        <p>参加しているワークスペースのURLを入力してください</p>
+        <div className="domain_inputs">
+          <span>/workspace/</span><input type="text" id="domain_input" className="biginput"/>
+        </div>
+        <p className="existence_error" style={this.state.error_style}>存在しないワークスペースです。</p>
+        <button onClick={this.confirm_domain.bind(this)} id="submit_domain" disabled={this.state.isdisabled}>
+          続行する
+        </button>
+      </form >
+    );
+  }
+}

--- a/app/javascript/packs/signin/workspace_domain.jsx
+++ b/app/javascript/packs/signin/workspace_domain.jsx
@@ -13,7 +13,7 @@ export default class WorkspaceDomain extends React.Component {
     }
   }
   confirm_domain() {
-    let input_domain = document.getElementById('domain_input').value
+    let input_domain = this.refs.domain.value
     this.setState({
       isdisabled: true,
       error_style: {
@@ -47,7 +47,7 @@ export default class WorkspaceDomain extends React.Component {
         <h1>ワークスペースにサインインする</h1>
         <p>参加しているワークスペースのURLを入力してください</p>
         <div className="domain_inputs">
-          <span>/workspace/</span><input type="text" id="domain_input" className="biginput"/>
+          <span>/workspace/</span><input type="text" id="domain_input" className="biginput" ref="domain"/>
         </div>
         <p className="existence_error" style={this.state.error_style}>存在しないワークスペースです。</p>
         <button onClick={this.confirm_domain.bind(this)} id="submit_domain" disabled={this.state.isdisabled}>

--- a/app/javascript/packs/signin/workspace_domain.jsx
+++ b/app/javascript/packs/signin/workspace_domain.jsx
@@ -46,7 +46,7 @@ export default class WorkspaceDomain extends React.Component {
       }}>
         <h1>ワークスペースにサインインする</h1>
         <p>参加しているワークスペースのURLを入力してください</p>
-        <div className="domain_inputs">
+        <div className="domain_input">
           <span>/workspace/</span><input type="text" id="domain_input" className="biginput" ref="domain"/>
         </div>
         <p className="existence_error" style={this.state.error_style}>存在しないワークスペースです。</p>

--- a/app/javascript/packs/welcome/workspace_menu.jsx
+++ b/app/javascript/packs/welcome/workspace_menu.jsx
@@ -6,7 +6,8 @@ export default class WSmenu extends React.Component {
       <div className="workspace_menu" style={{
         display: this.props.style
       }}>
-        <a href="/workspaces" target="_blank">Create New Workspace</a>
+      <a href="/signin" target="_blank">他のワークスペースにサインインする</a>
+      <a href="/workspaces" target="_blank">ワークスペースの作成</a>
       </div>
     );
   }

--- a/app/views/signin/new.html.erb
+++ b/app/views/signin/new.html.erb
@@ -1,0 +1,4 @@
+<a href="/"><%= image_tag 'logo', :id => 'mock_logo' %></a>
+<div id='content'></div>
+<%= javascript_pack_tag 'signin' %>
+<%= stylesheet_link_tag 'scss/new_workspace', :media => 'all' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
   post '/emails', to: 'email_verification#new'
   post '/emails/code/check', to: 'email_verification#check_code'
   get '/signin', to: 'signin#new'
+  post 'signin', to: 'signin#issue_jwt'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   post '/workspaces/domain/check', to: 'workspaces#check_domain'
   post '/emails', to: 'email_verification#new'
   post '/emails/code/check', to: 'email_verification#check_code'
+  get '/signin', to: 'signin#new'
 end

--- a/db/migrate/20171203061638_add_token_to_user.rb
+++ b/db/migrate/20171203061638_add_token_to_user.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddTokenToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171125231616) do
+ActiveRecord::Schema.define(version: 20171203061638) do
 
   create_table "emails", force: :cascade do |t|
     t.string "address"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20171125231616) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
+    t.string "token"
     t.index ["email", "workspace_id"], name: "index_users_on_email_and_workspace_id", unique: true
     t.index ["workspace_id"], name: "index_users_on_workspace_id"
   end


### PR DESCRIPTION
- /signinにサインインフォームを追加
- サインインするドメインを入力
→ POST /workspaces/domain/check で存在を検証
- メールアドレスとパスワードを入力
→ POST /signin で有効か検証
- 有効ならJWTを生成してクライアントに返す&User.tokenに保存
- JWTをLocal Storageに保存