### PR TITLE
ユーザーがチャンネルに参加する機能を追加

### DIFF
--- a/app/assets/stylesheets/scss/workspace_pop.scss
+++ b/app/assets/stylesheets/scss/workspace_pop.scss
@@ -1,4 +1,4 @@
-#create_channel_pop {
+#create_channel_pop, #participate_channel_pop {
   position: absolute;
   top: 0;
   left: 0;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,10 @@ class ApplicationController < ActionController::Base
     @available_channels = @channels - @joined_channels
     render 'workspaces/data', formats: 'json', handlers: 'jbuilder'
   end
+  def current_user
+    decoded_token = JWT.decode(params[:jwt], Rails.application.secrets.secret_key_base, true, algorithm: 'HS256')
+    email = decoded_token[0]['email']
+    workspace_id = decoded_token[0]['workspace_id']
+    User.find_by(workspace_id: workspace_id, email: email)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  def channel_data_json
+    @channels = Channel.where(workspace_id: current_user.workspace_id, public: true).pluck(:name)
+    @joined_channels = current_user.channels.pluck(:name)
+    @available_channels = @channels - @joined_channels
+    render 'workspaces/data', formats: 'json', handlers: 'jbuilder'
+  end
 end

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 class ChannelsController < ApplicationController
   def create
-    p current_user
-    p channel_params
     if Channel.exists?(workspace_id: current_user.workspace_id, name: channel_params[:name])
       render json: { success: false }
     else
@@ -12,6 +10,15 @@ class ChannelsController < ApplicationController
       channel.save!
       ChannelUser.create(channel_id: channel.id, user_id: current_user.id)
       render json: { success: true }
+    end
+  end
+  def join
+    channel = Channel.find_by(name: channel_params[:name])
+    if ChannelUser.exists?(channel_id: channel.id, user_id: current_user.id)
+      render json: { success: false }
+    else
+      ChannelUser.create(channel_id: channel.id, user_id: current_user.id)
+      channel_data_json
     end
   end
 

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -9,7 +9,6 @@ class ChannelsController < ApplicationController
       channel = Channel.new(channel_params)
       channel.workspace_id = current_user.workspace_id
       channel.count = 1
-      p channel
       channel.save!
       ChannelUser.create(channel_id: channel.id, user_id: current_user.id)
       render json: { success: true }

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -27,10 +27,4 @@ class ChannelsController < ApplicationController
   def channel_params
     params.require(:channel).permit(:name, :topic, :public)
   end
-  def current_user
-    decoded_token = JWT.decode(params[:jwt], Rails.application.secrets.secret_key_base, true, algorithm: 'HS256')
-    email = decoded_token[0]['email']
-    workspace_id = decoded_token[0]['workspace_id']
-    User.find_by(workspace_id: workspace_id, email: email)
-  end
 end

--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -30,10 +30,7 @@ class WorkspacesController < ApplicationController
   def show
   end
   def data
-    @channels = Channel.where(workspace_id: current_user.workspace_id, public: true).pluck(:name)
-    @joined_channels = current_user.channels.pluck(:name)
-    @available_channels = @channels - @joined_channels
-    render 'workspaces/data', formats: 'json', handlers: 'jbuilder'
+    channel_data_json
   end
 
   private

--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -30,7 +30,8 @@ class WorkspacesController < ApplicationController
   def show
   end
   def data
-    render json: { success: true }
+    @channels = Channel.where(workspace_id: current_user.workspace_id)
+    render 'workspaces/data', formats: 'json', handlers: 'jbuilder'
   end
 
   private

--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -44,10 +44,4 @@ class WorkspacesController < ApplicationController
   def email_params
     params.require(:email).permit(:token)
   end
-  def current_user
-    decoded_token = JWT.decode(params[:jwt], Rails.application.secrets.secret_key_base, true, algorithm: 'HS256')
-    email = decoded_token[0]['email']
-    workspace_id = decoded_token[0]['workspace_id']
-    User.find_by(workspace_id: workspace_id, email: email)
-  end
 end

--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -30,7 +30,9 @@ class WorkspacesController < ApplicationController
   def show
   end
   def data
-    @channels = Channel.where(workspace_id: current_user.workspace_id)
+    @channels = Channel.where(workspace_id: current_user.workspace_id, public: true).pluck(:name)
+    @joined_channels = current_user.channels.pluck(:name)
+    @available_channels = @channels - @joined_channels
     render 'workspaces/data', formats: 'json', handlers: 'jbuilder'
   end
 

--- a/app/javascript/packs/workspace/popup/participate_channel_pop.jsx
+++ b/app/javascript/packs/workspace/popup/participate_channel_pop.jsx
@@ -19,6 +19,7 @@ export default class ParticipateChannelPop extends React.Component {
             <button className="close_btn" onClick={this.hide.bind(this)}>×</button>
           </div>
           <form>
+            
           </form>
         </div>
       </div>

--- a/app/javascript/packs/workspace/popup/participate_channel_pop.jsx
+++ b/app/javascript/packs/workspace/popup/participate_channel_pop.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import axios from 'axios'
+
+export default class ParticipateChannelPop extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+    }
+  }
+  hide() {
+    this.props.update_state({participate_channel_pop: false})
+  }
+  render() {
+    return (
+      <div id="participate_channel_pop">
+        <div className="pop_container">
+          <h1>Join channels</h1>
+          <div id="right_up">
+            <button className="close_btn" onClick={this.hide.bind(this)}>×</button>
+          </div>
+          <form>
+          </form>
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/javascript/packs/workspace/popup/participate_channel_pop.jsx
+++ b/app/javascript/packs/workspace/popup/participate_channel_pop.jsx
@@ -5,10 +5,36 @@ export default class ParticipateChannelPop extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
+      isdisabled: true,
+      selected_channel: ""
     }
   }
   hide() {
     this.props.update_state({participate_channel_pop: false})
+  }
+  change_radio(e) {
+    this.setState({
+      isdisabled: false,
+      selected_channel: e.target.value
+    })
+  }
+  submit_join(e){
+    e.preventDefault()
+    axios.defaults.headers['X-CSRF-TOKEN'] = this.props.grandparentstate.csrf_token
+    axios.post('/channels/join', {
+      jwt: this.props.grandparentstate.jwt,
+      channel: {
+        name: this.state.selected_channel
+      }
+    }).then((results) => {
+      if (results.data.success) {
+        delete(results.data.success)
+        this.props.update_parent_state(results.data.success)
+        this.hide()
+      }
+    },).catch(() => {
+      alert('エラー')
+    });
   }
   render() {
     return (
@@ -19,7 +45,20 @@ export default class ParticipateChannelPop extends React.Component {
             <button className="close_btn" onClick={this.hide.bind(this)}>×</button>
           </div>
           <form>
-            
+            <div className="input_group">
+              {this.props.grandparentstate.available_channels.map((name) => {
+                return (
+                  <div className="check_channels">
+                    <input type="radio" value={name} name="channels" onChange={this.change_radio.bind(this)}/>
+                    <span>{name}</span>
+                  </div>
+                )
+              })
+}
+            </div>
+            <div className="input_group">
+              <button className="large_btn" disabled={this.state.isdisabled} onClick={this.submit_join.bind(this)}>Join Channel</button>
+            </div>
           </form>
         </div>
       </div>

--- a/app/javascript/packs/workspace/popup/participate_channel_pop.jsx
+++ b/app/javascript/packs/workspace/popup/participate_channel_pop.jsx
@@ -29,7 +29,7 @@ export default class ParticipateChannelPop extends React.Component {
     }).then((results) => {
       if (results.data.success) {
         delete(results.data.success)
-        this.props.update_parent_state(results.data.success)
+        this.props.update_parent_state(results.data)
         this.hide()
       }
     },).catch(() => {
@@ -46,9 +46,9 @@ export default class ParticipateChannelPop extends React.Component {
           </div>
           <form>
             <div className="input_group">
-              {this.props.grandparentstate.available_channels.map((name) => {
+              {this.props.grandparentstate.available_channels.map((name,n) => {
                 return (
-                  <div className="check_channels">
+                  <div key={n} className="check_channels">
                     <input type="radio" value={name} name="channels" onChange={this.change_radio.bind(this)}/>
                     <span>{name}</span>
                   </div>

--- a/app/javascript/packs/workspace/side_container.jsx
+++ b/app/javascript/packs/workspace/side_container.jsx
@@ -18,7 +18,6 @@ export default class SideContainer extends React.Component {
     axios.post('/workspaces/data', {jwt: this.props.parentstate.jwt}).then((results) => {
       if (results.data.success) {
         delete(results.data.success)
-        console.log(results.data)
         this.props.update_state(results.data)
       }
     },).catch(() => {

--- a/app/javascript/packs/workspace/side_container.jsx
+++ b/app/javascript/packs/workspace/side_container.jsx
@@ -2,11 +2,13 @@ import React from 'react'
 import axios from 'axios'
 
 import CreateChannelPop from './popup/create_channel_pop.jsx'
+import ParticipateChannelPop from './popup/participate_channel_pop.jsx'
 export default class SideContainer extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
       channels: {},
+      create_channel_pop: false,
       create_channel_pop: false
     }
     this.workspace_data()
@@ -27,6 +29,9 @@ export default class SideContainer extends React.Component {
   pop_create_channel(){
     this.setState({create_channel_pop: true})
   }
+  pop_participate_channel(){
+    this.setState({participate_channel_pop: true})
+  }
   update_state(obj){
     this.setState(obj)
   }
@@ -37,13 +42,14 @@ export default class SideContainer extends React.Component {
         <div id="starred_menu"></div>
         <div id="channel_menu">
           <p className="menu_line">
-            <button id="channels_button">Channels</button>
+            <button id="channels_button" onClick={this.pop_participate_channel.bind(this)}>Channels</button>
             <button id="create_channel_button" onClick={this.pop_create_channel.bind(this)}>+</button>
           </p>
         </div>
         <div id="dm_menu"></div>
         <div id="bottom_menu"></div>
-        {(()=>{if(this.state.create_channel_pop){return <CreateChannelPop update_state={this.update_state.bind(this)} grandparentstate={this.props.parentstate} />}})()}
+          {(()=>{if(this.state.create_channel_pop){return <CreateChannelPop update_state={this.update_state.bind(this)} grandparentstate={this.props.parentstate} />}})()}
+          {(()=>{if(this.state.participate_channel_pop){return <ParticipateChannelPop update_state={this.update_state.bind(this)} grandparentstate={this.props.parentstate} />}})()}
       </div>
     );
   }

--- a/app/javascript/packs/workspace/side_container.jsx
+++ b/app/javascript/packs/workspace/side_container.jsx
@@ -34,6 +34,9 @@ export default class SideContainer extends React.Component {
   update_state(obj){
     this.setState(obj)
   }
+  update_parent_state(obj){
+    this.props.update_state(obj)
+  }
   render() {
     return (
       <div id="side_container">
@@ -48,7 +51,7 @@ export default class SideContainer extends React.Component {
         <div id="dm_menu"></div>
         <div id="bottom_menu"></div>
           {(()=>{if(this.state.create_channel_pop){return <CreateChannelPop update_state={this.update_state.bind(this)} grandparentstate={this.props.parentstate} />}})()}
-          {(()=>{if(this.state.participate_channel_pop){return <ParticipateChannelPop update_state={this.update_state.bind(this)} grandparentstate={this.props.parentstate} />}})()}
+          {(()=>{if(this.state.participate_channel_pop){return <ParticipateChannelPop update_state={this.update_state.bind(this)} update_parent_state={this.update_parent_state.bind(this)} grandparentstate={this.props.parentstate} />}})()}
       </div>
     );
   }

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Channel < ApplicationRecord
   belongs_to :workspace
-  has_many :user, through: :channel_user
-  has_many :channel_user
+  has_many :channel_users
+  has_many :users, through: :channel_users
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,6 @@ class User < ApplicationRecord
   before_save { self.email = email.downcase }
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }
-  has_many :channel, through: :channel_user
-  has_many :channel_user
+  has_many :channel_users
+  has_many :channels, through: :channel_users
 end

--- a/app/views/workspaces/data.json.jbuilder
+++ b/app/views/workspaces/data.json.jbuilder
@@ -1,0 +1,2 @@
+json.channel @channels, :name
+json.success true

--- a/app/views/workspaces/data.json.jbuilder
+++ b/app/views/workspaces/data.json.jbuilder
@@ -1,2 +1,4 @@
-json.channel @channels, :name
+json.channels @channels
+json.joined_channels @joined_channels
+json.available_channels @available_channels
 json.success true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   post '/emails/code/check', to: 'emails#check_code'
   resource :signin, only: [:new, :create]
   resources :channels, only: [:create]
+  post '/channels/join', to: 'channels#join'
 end


### PR DESCRIPTION
- ChannelUserモデル（中間テーブル）にユーザのチャンネル参加状況を保存
- post /channels/join　で参加状況を変更
- 各ユーザの参加状況はApplicationController#channel_dataでjsonで出力、クライアント側はside_containerの読み込み時に取得