### PR TITLE
チャット画面のヘッダーとフッターのUIを追加

### DIFF
--- a/app/assets/stylesheets/scss/workspace.scss
+++ b/app/assets/stylesheets/scss/workspace.scss
@@ -5,7 +5,6 @@ body {
 #client_container,
 #client_ui,
 #content,
-#flex_column,
 #main_container,
 #message_column,
 #side_container,

--- a/app/assets/stylesheets/scss/workspace_main.scss
+++ b/app/assets/stylesheets/scss/workspace_main.scss
@@ -1,0 +1,86 @@
+#header_column {
+  width: 100%;
+  top: 0;
+  display: flex;
+  padding: 2px 0 0;
+  height: 50px;
+  border-bottom: 1px solid #ececec;
+
+  .header_left {
+    display: flex;
+    flex-direction: column;
+    padding-left: 20px;
+
+    .channel_name_span {
+      font-size: 16px;
+      display: block;
+    }
+
+    .channel_header_info {
+      margin-top: -6px;
+
+      .star_btn {
+        font-size: 14px;
+        background-color: transparent;
+        border: none;
+        padding: 0;
+        color: #ababab;
+      }
+
+      .star_btn::after {
+        margin: 0 5px;
+        content: "|";
+      }
+
+      .members_count_btn {
+        font-size: 14px;
+        background-color: transparent;
+        border: none;
+        padding: 0;
+        color: #ababab;
+      }
+
+      .members_count_btn::after {
+        margin: 0 5px;
+        content: "|";
+      }
+
+      .edit_topic_btn {
+        font-size: 14px;
+        background-color: transparent;
+        border: none;
+        padding: 0;
+        color: #ababab;
+      }
+    }
+  }
+}
+#message_column{
+  overflow: scroll;
+}
+#fixed_column {
+  bottom: 0;
+  .message_form {
+    display: flex;
+    flex-direction: row;
+
+    .editable_div {
+      flex: 1;
+      padding: 9px;
+      margin: 5px;
+      border: 1px solid #ececec;
+    }
+
+    .submit_btn {
+      background: #2ea664;
+      color: #fff;
+      border: none;
+      width: 80px;
+      text-align: center;
+      margin: 5px;
+      border-radius: 10px;
+      font-weight: 900;
+      font-size: 16px;
+    }
+  }
+}

--- a/app/assets/stylesheets/scss/workspace_main.scss
+++ b/app/assets/stylesheets/scss/workspace_main.scss
@@ -17,7 +17,7 @@
     }
 
     .channel_header_info {
-      margin-top: -6px;
+      margin-top: -9px;
 
       .star_btn {
         font-size: 14px;

--- a/app/assets/stylesheets/scss/workspace_pop.scss
+++ b/app/assets/stylesheets/scss/workspace_pop.scss
@@ -10,6 +10,7 @@
   background-color: #ffffff;
   justify-content: center;
   align-items: flex-start;
+  z-index: 1;
 
   form {
     display: flex;

--- a/app/assets/stylesheets/scss/workspace_side.scss
+++ b/app/assets/stylesheets/scss/workspace_side.scss
@@ -14,6 +14,7 @@
   min-width: 1px;
   max-width: 260px;
   background: #4d394b;
+  overflow-y: scroll;
 
   .menu_line {
     margin: 0;

--- a/app/javascript/packs/workspace.jsx
+++ b/app/javascript/packs/workspace.jsx
@@ -19,7 +19,6 @@ class Parent extends React.Component {
       channel: "WorkspaceChannel"
     }, {
       connected: function() {
-        alert('done')
       }, //接続時
       disconnected: function() {}, //切断時
       received: function(data) { //受信時
@@ -43,7 +42,7 @@ class Parent extends React.Component {
       <div id="client_ui">
         <div id="client_container">
           <SideContainer parentstate={this.state} update_state={this.update_state.bind(this)} switch_channel={this.switch_channel.bind(this)}/>
-          <MainContainer/>
+          <MainContainer parentstate={this.state} update_state={this.update_state.bind(this)}/>
         </div>
       </div>
     )

--- a/app/javascript/packs/workspace.jsx
+++ b/app/javascript/packs/workspace.jsx
@@ -13,13 +13,12 @@ class Parent extends React.Component {
     this.state = {
       jwt: JSON.parse(localStorage.getItem(domain)).token,
       csrf_token: document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
-      selected_channel:""
+      selected_channel: ""
     }
     App.room = App.cable.subscriptions.create({
       channel: "WorkspaceChannel"
     }, {
-      connected: function() {
-      }, //接続時
+      connected: function() {}, //接続時
       disconnected: function() {}, //切断時
       received: function(data) { //受信時
       },
@@ -32,8 +31,14 @@ class Parent extends React.Component {
       console.log(this.state)
     })
   }
-  switch_channel(channel){
-    this.setState({selected_channel: channel},()=>{
+  switch_channel(channel) {
+    var selected_channel = this.state.joined_channels.filter(function(item, i) {
+      if (item.name == channel)
+        return true
+    })
+    this.setState({
+      selected_channel: selected_channel[0]
+    }, () => {
       // switch
     })
   }

--- a/app/javascript/packs/workspace/main/channel_header.jsx
+++ b/app/javascript/packs/workspace/main/channel_header.jsx
@@ -15,14 +15,20 @@ export default class ChannelHeader extends React.Component {
     }
   }
   render() {
+    var topic
+    if(!!this.props.grandparentstate.selected_channel.topic){
+         topic = "トピック: "+this.props.grandparentstate.selected_channel.topic
+    }else {
+       topic = "トピックを追加"
+    }
     return (
       <div id="channel_header_container">
         <div className="header_left">
           <span className="channel_name_span"># {this.props.grandparentstate.selected_channel.name}</span>
           <div className="channel_header_info">
             <button className="star_btn" onClick={this.click_star.bind(this)}>☆</button>
-            <button className="members_count_btn">n</button>
-            <button className="edit_topic_btn">トピックを編集</button>
+            <button className="members_count_btn">{this.props.grandparentstate.selected_channel.count}人</button>
+            <button className="edit_topic_btn">{topic}</button>
           </div>
         </div>
       </div>

--- a/app/javascript/packs/workspace/main/channel_header.jsx
+++ b/app/javascript/packs/workspace/main/channel_header.jsx
@@ -7,13 +7,20 @@ export default class ChannelHeader extends React.Component {
     this.state = {
     }
   }
+  click_star(e){
+    if(e.target.innerText == "☆"){
+    e.target.innerText="★"
+  }else{
+    e.target.innerText="☆"
+    }
+  }
   render() {
     return (
       <div id="channel_header_container">
         <div className="header_left">
           <span className="channel_name_span"># {this.props.grandparentstate.selected_channel}</span>
           <div className="channel_header_info">
-            <button className="star_btn">☆</button>
+            <button className="star_btn" onClick={this.click_star.bind(this)}>☆</button>
             <button className="members_count_btn">n</button>
             <button className="edit_topic_btn">トピックを編集</button>
           </div>

--- a/app/javascript/packs/workspace/main/channel_header.jsx
+++ b/app/javascript/packs/workspace/main/channel_header.jsx
@@ -18,7 +18,7 @@ export default class ChannelHeader extends React.Component {
     return (
       <div id="channel_header_container">
         <div className="header_left">
-          <span className="channel_name_span"># {this.props.grandparentstate.selected_channel}</span>
+          <span className="channel_name_span"># {this.props.grandparentstate.selected_channel.name}</span>
           <div className="channel_header_info">
             <button className="star_btn" onClick={this.click_star.bind(this)}>☆</button>
             <button className="members_count_btn">n</button>

--- a/app/javascript/packs/workspace/main/channel_header.jsx
+++ b/app/javascript/packs/workspace/main/channel_header.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import axios from 'axios'
+
+export default class ChannelHeader extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+    }
+  }
+  render() {
+    return (
+      <div id="channel_header_container">
+        <div className="header_left">
+          <span className="channel_name_span"># {this.props.grandparentstate.selected_channel}</span>
+          <div className="channel_header_info">
+            <button className="star_btn">☆</button>
+            <button className="members_count_btn">n</button>
+            <button className="edit_topic_btn">トピックを編集</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/app/javascript/packs/workspace/main/message_form.jsx
+++ b/app/javascript/packs/workspace/main/message_form.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export default class MessageForm extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      isdisabled: false
+    }
+  }
+  render() {
+    return (
+      <form className="message_form">
+        <div className="editable_div" contentEditable="true"></div>
+        <button className="submit_btn" disabled={this.state.isdisabled}>送信</button>
+      </form>
+    );
+
+  }
+}

--- a/app/javascript/packs/workspace/main_container.jsx
+++ b/app/javascript/packs/workspace/main_container.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import ChannelHeader from './main/channel_header.jsx'
+import MessageForm from './main/message_form.jsx'
 export default class MainContainer extends React.Component {
   constructor(props) {
     super(props)
@@ -7,11 +9,22 @@ export default class MainContainer extends React.Component {
     }
   }
   render() {
+    if(!!this.props.parentstate.selected_channel){
     return (
       <div id="main_container">
-        <div id="message_column"></div>
-        <div id="flex_column"></div>
+        <div id="header_column">
+          <ChannelHeader grandparentstate={this.props.parentstate}/>
+        </div>
+        <div id="message_column">
+          
+        </div>
+        <div id="fixed_column">
+          <MessageForm grandparentstate={this.props.parentstate}/>
+        </div>
       </div>
     );
+  }else{
+    return (<p>select something</p>)
+  }
   }
 }

--- a/app/views/workspaces/show.html.erb
+++ b/app/views/workspaces/show.html.erb
@@ -3,3 +3,4 @@
 <%= stylesheet_link_tag 'scss/workspace', :media => 'all' %>
 <%= stylesheet_link_tag 'scss/workspace_pop', :media => 'all' %>
 <%= stylesheet_link_tag 'scss/workspace_side', :media => 'all' %>
+<%= stylesheet_link_tag 'scss/workspace_main', :media => 'all' %>


### PR DESCRIPTION
- Parentコンポーネントのstateでチャンネルの名前だけ保存していたものを、チャンネルの名前・トピック・参加人数をオブジェクトにして保存
- メインコンテナの上部にチャンネル名とスターと人数とトピックを表示するヘッダを追加
- メインコンテナの下部にメッセージ送信部分になるフッタを追加