### PR TITLE
ユーザーのオンライン/オフラインを管理するappearanceチャンネルを追加

### DIFF
--- a/app/assets/stylesheets/scss/workspace_side.scss
+++ b/app/assets/stylesheets/scss/workspace_side.scss
@@ -21,6 +21,12 @@
     font-style: normal;
     margin-right: 10px;
   }
+  .inactive_user_mark {
+    color: #dbdbdb;
+    font-size: 10px;
+    font-style: normal;
+    margin-right: 10px;
+  }
 
   #team_menu:hover {
     background-color: #2e222d;

--- a/app/channels/appearance_channel.rb
+++ b/app/channels/appearance_channel.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+class AppearanceChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "appearance_of_#{current_user.workspace.domain}"
+    current_user.update_attribute(:status, 1)
+    broadcast_appearance
+  end
+
+  def unsubscribed
+    current_user.update_attribute(:status, 0)
+    broadcast_appearance
+  end
+
+  private
+
+  def broadcast_appearance
+    ActionCable.server.broadcast(
+      "appearance_of_#{current_user.workspace.domain}",
+      users: usersjson
+    )
+  end
+  def usersjson
+    User.where(workspace_id: current_user.workspace_id).select('display_name', 'user_name', 'status').as_json
+  end
+end

--- a/app/channels/appearance_channel.rb
+++ b/app/channels/appearance_channel.rb
@@ -11,15 +11,19 @@ class AppearanceChannel < ApplicationCable::Channel
     broadcast_appearance
   end
 
+  def activate_user
+    # 複数タブで開いてる場合に１つタブが閉じられた場合の対策
+    # current_user.update_attribute(:status, 1)がなぜか動かないので↓
+    User.find(current_user.id).update_attribute(:status, 1)
+    broadcast_appearance
+  end
+
   private
 
   def broadcast_appearance
     ActionCable.server.broadcast(
       "appearance_of_#{current_user.workspace.domain}",
-      users: usersjson
+      users: User.where(workspace_id: current_user.workspace_id).select('display_name', 'user_name', 'status').as_json
     )
-  end
-  def usersjson
-    User.where(workspace_id: current_user.workspace_id).select('display_name', 'user_name', 'status').as_json
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   def channel_data_json
-    @display_name = current_user.display_name
+    @current_user = current_user
     @workspace_name = current_user.workspace.name
     @channels = Channel.where(workspace_id: current_user.workspace_id, public: true).select('name', 'topic', 'count')
     @joined_channels = current_user.channels.select('name', 'topic', 'count')

--- a/app/javascript/packs/workspace.jsx
+++ b/app/javascript/packs/workspace.jsx
@@ -25,7 +25,7 @@ class Parent extends React.Component {
       connected: function() {}, //接続時
       disconnected: function() {}, //切断時
       received: function(data) { //受信時
-        self.setState({users: data.users}})
+        self.setState({users: data.users})
       },
       send_message: function(message) { //送信時
       }

--- a/app/javascript/packs/workspace.jsx
+++ b/app/javascript/packs/workspace.jsx
@@ -16,12 +16,16 @@ class Parent extends React.Component {
       selected_channel: "",
       domain: domain
     }
-    App.room = App.cable.subscriptions.create({
-      channel: "WorkspaceChannel"
+  }
+  componentDidMount(){
+    let self = this
+    App.appearance = App.cable.subscriptions.create({
+      channel: "AppearanceChannel"
     }, {
       connected: function() {}, //接続時
       disconnected: function() {}, //切断時
       received: function(data) { //受信時
+        self.setState({users: data.users}})
       },
       send_message: function(message) { //送信時
       }

--- a/app/javascript/packs/workspace.jsx
+++ b/app/javascript/packs/workspace.jsx
@@ -29,15 +29,9 @@ class Parent extends React.Component {
         let user_arr = data.users.filter((user)=>{
           if(user.user_name == self.state.user_name) return true
         })
-        console.log(user_arr)
         if (user_arr[0] && user_arr[0].status == 0){
           this.perform('activate_user')
         }
-      },
-      send_message: function(message) { //送信時
-      },
-      send_status: ()=>{
-
       }
     })
   }

--- a/app/javascript/packs/workspace.jsx
+++ b/app/javascript/packs/workspace.jsx
@@ -26,13 +26,24 @@ class Parent extends React.Component {
       disconnected: function() {}, //切断時
       received: function(data) { //受信時
         self.setState({users: data.users})
+        let user_arr = data.users.filter((user)=>{
+          if(user.user_name == self.state.user_name) return true
+        })
+        console.log(user_arr)
+        if (user_arr[0] && user_arr[0].status == 0){
+          this.perform('activate_user')
+        }
       },
       send_message: function(message) { //送信時
+      },
+      send_status: ()=>{
+
       }
     })
   }
   update_state(obj) {
     this.setState(obj, () => {
+      console.log(this.state)
       if(!!this.state.selected_channel){
       this.switch_channel(this.state.selected_channel.name)
       }

--- a/app/javascript/packs/workspace/side_container.jsx
+++ b/app/javascript/packs/workspace/side_container.jsx
@@ -78,10 +78,18 @@ export default class SideContainer extends React.Component {
         <p key="dm" className="menu_line">Direct Messages</p>
       )
       this.props.parentstate.users.map((user, i) => {
-        users.push(
-          <p className="user_line" key={i} data-user-name={user.user_name}>
-            <i className="active_user_mark">●</i>{user.display_name}</p>
-        )
+        if(user.status == 1){
+          users.push(
+            <p className="user_line" key={i} data-user-name={user.user_name}>
+              <i className="active_user_mark">●</i>{user.display_name}</p>
+          )
+        }else{
+          users.push(
+            <p className="user_line" key={i} data-user-name={user.user_name}>
+              <i className="inactive_user_mark">○</i>{user.display_name}</p>
+          )
+        }
+
       })
     }
     var team_menu_pop = []

--- a/app/views/workspaces/data.json.jbuilder
+++ b/app/views/workspaces/data.json.jbuilder
@@ -1,5 +1,6 @@
 json.workspace_name @workspace_name
-json.display_name @display_name
+json.display_name @current_user.display_name
+json.user_name @current_user.user_name
 json.channels @channels
 json.joined_channels @joined_channels
 json.available_channels @available_channels

--- a/db/migrate/20171216034145_add_stared_to_channel_user.rb
+++ b/db/migrate/20171216034145_add_stared_to_channel_user.rb
@@ -1,4 +1,4 @@
-class AddstarredToChannelUser < ActiveRecord::Migration[5.1]
+class AddstaredToChannelUser < ActiveRecord::Migration[5.1]
   def change
     add_column :channel_users, :stared, :boolean, default: false
   end

--- a/db/migrate/20171226171259_add_defaults_to_user_status.rb
+++ b/db/migrate/20171226171259_add_defaults_to_user_status.rb
@@ -1,0 +1,5 @@
+class AddDefaultsToUserStatus < ActiveRecord::Migration[5.1]
+  def change
+    change_column :users, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171218101846) do
+ActiveRecord::Schema.define(version: 20171226171259) do
 
   create_table "channel_users", force: :cascade do |t|
     t.integer "user_id"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20171218101846) do
     t.string "email"
     t.string "user_name"
     t.string "display_name"
-    t.integer "status"
+    t.integer "status", default: 0
     t.integer "invited_by"
     t.integer "role"
     t.string "phone"


### PR DESCRIPTION
- Userモデルのstatusカラムが0でオフライン1でオンライン
- 参加中のユーザーのオンラインステータスが変わる度にappearanceチャンネルで全ユーザーのステータスを配信
- JSONで受信してthis.state.usersに保存